### PR TITLE
Prevent errors on caching posts with no location

### DIFF
--- a/src/Console/TinygramCache.php
+++ b/src/Console/TinygramCache.php
@@ -49,7 +49,7 @@ class TinygramCache extends Command
                 Tinyimage::create([
                     'media_id' => $post['id'],
                     'link' => $post['link'],
-                    'location' => $post['location'] ? $post['location']['name'] : '',
+                    'location' => $post['location']['name'],
                     'standard_url' => $post['images']['standard_resolution']['url'],
                     'thumb_url' => $post['images']['thumbnail']['url'],
                     'media_created_at' => Carbon::createFromTimestamp($post['created_time']),

--- a/src/Console/TinygramCache.php
+++ b/src/Console/TinygramCache.php
@@ -49,7 +49,7 @@ class TinygramCache extends Command
                 Tinyimage::create([
                     'media_id' => $post['id'],
                     'link' => $post['link'],
-                    'location' => $post['location']['name'],
+                    'location' => $post['location'] ? $post['location']['name'] : '',
                     'standard_url' => $post['images']['standard_resolution']['url'],
                     'thumb_url' => $post['images']['thumbnail']['url'],
                     'media_created_at' => Carbon::createFromTimestamp($post['created_time']),

--- a/src/Database/migrations/2019_09_04_093240_update_tinyimages_table_location_nullable.php
+++ b/src/Database/migrations/2019_09_04_093240_update_tinyimages_table_location_nullable.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateTinyimagesTableLocationNullable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tinyimages', function (Blueprint $table) {
+            $table->string('location')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tinyimages', function (Blueprint $table) {
+            $table->string('location')->nullable(false)->change();
+        });
+    }
+}


### PR DESCRIPTION
Whats good big T, 

When running the `tinygram:cache` command, if a post with no location is pulled in, an error will be thrown as the location column can't be null.

Happy to go with this? or would you prefer a migration update and set the column to nullable?

Stan.